### PR TITLE
fix image repo in helm chart

### DIFF
--- a/helm/khook/values.yaml
+++ b/helm/khook/values.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 
 image:
-  registry: cr.kagent.dev
+  registry: ghcr.io
   repository: kagent-dev/khook/khook
   pullPolicy: IfNotPresent
   # tag will default to Chart.AppVersion if not specified


### PR DESCRIPTION
Failed to pull image "cr.kagent.dev/kagent-dev/khook:0.0.4": rpc error: code = NotFound desc = failed to pull and unpack image "cr.kagent.dev/kagent-dev/khook:0.0.4"